### PR TITLE
Get Seed Manifests from V2 api

### DIFF
--- a/registry/RegistryFactory.go
+++ b/registry/RegistryFactory.go
@@ -12,67 +12,67 @@ import (
 type RepositoryRegistry interface {
 	Name() string
 	Ping() error
-	Repositories(org string) ([]string, error)
-	Tags(repository, org string) ([]string, error)
-	Images(org string) ([]string, error)
-	ImagesWithManifests(org string) ([]objects.Image, error)
-	GetImageManifest(image, org string) (string, error)
+	Repositories() ([]string, error)
+	Tags(repository string) ([]string, error)
+	Images() ([]string, error)
+	ImagesWithManifests() ([]objects.Image, error)
+	GetImageManifest(repoName, tag string) (string, error)
 }
 
-type RepoRegistryFactory func(url, username, password string) (RepositoryRegistry, error)
+type RepoRegistryFactory func(url, org, username, password string) (RepositoryRegistry, error)
 
-func NewV2Registry(url, username, password string) (RepositoryRegistry, error) {
-	v2registry, err := v2.New(url, username, password)
+func NewV2Registry(url, org, username, password string) (RepositoryRegistry, error) {
+	v2registry, err := v2.New(url, org, username, password)
 	if err != nil {
 		if strings.Contains(url, "https://") {
 			httpFallback := strings.Replace(url, "https://", "http://", 1)
-			v2registry, err = v2.New(httpFallback, username, password)
+			v2registry, err = v2.New(httpFallback, org, username, password)
 		}
 	}
 
 	return v2registry, err
 }
 
-func NewDockerHubRegistry(url, username, password string) (RepositoryRegistry, error) {
-	hub, err := dockerhub.New(url)
+func NewDockerHubRegistry(url, org, username, password string) (RepositoryRegistry, error) {
+	hub, err := dockerhub.New(url, org)
 	if err != nil {
 		if strings.Contains(url, "https://") {
 			httpFallback := strings.Replace(url, "https://", "http://", 1)
-			hub, err = dockerhub.New(httpFallback)
+			hub, err = dockerhub.New(httpFallback, org)
 		}
 	}
 
 	return hub, err
 }
 
-func NewContainerYardRegistry(url, username, password string) (RepositoryRegistry, error) {
-	yard, err := containeryard.New(url, username, password)
+func NewContainerYardRegistry(url, org, username, password string) (RepositoryRegistry, error) {
+	yard, err := containeryard.New(url, org, username, password)
 	if err != nil {
 		if strings.Contains(url, "https://") {
 			httpFallback := strings.Replace(url, "https://", "http://", 1)
-			yard, err = containeryard.New(httpFallback, username, password)
+			yard, err = containeryard.New(httpFallback, org, username, password)
 		}
 	}
 
 	return yard, err
 }
 
-func CreateRegistry(url, username, password string) (RepositoryRegistry, error) {
+func CreateRegistry(url, org, username, password string) (RepositoryRegistry, error) {
 	if !strings.HasPrefix(url, "http") {
 		url = "https://" + url
 	}
 
-	v2, err1 := NewV2Registry(url, username, password)
+	v2, err1 := NewV2Registry(url, org, username, password)
 	if err1 == nil && v2 != nil && v2.Ping() == nil {
 		return v2, nil
 	}
 
-	hub, err2 := NewDockerHubRegistry(url, username, password)
+	hub, err2 := NewDockerHubRegistry(url, org, username, password)
 	if err2 == nil && hub != nil && hub.Ping() == nil {
 		return hub, nil
 	}
 
-	yard, err3 := NewContainerYardRegistry(url, username, password)
+	yard, err3 := NewContainerYardRegistry(url, org, username, password)
 	if err3 == nil && yard != nil && yard.Ping() == nil {
 		return yard, nil
 	}

--- a/registry/RegistryFactory.go
+++ b/registry/RegistryFactory.go
@@ -1,6 +1,8 @@
 package registry
 
 import (
+	"errors"
+	"fmt"
 	"strings"
 
 	"github.com/ngageoint/seed-common/objects"
@@ -63,19 +65,34 @@ func CreateRegistry(url, org, username, password string) (RepositoryRegistry, er
 	}
 
 	v2, err1 := NewV2Registry(url, org, username, password)
-	if err1 == nil && v2 != nil && v2.Ping() == nil {
-		return v2, nil
+	if err1 == nil {
+		if v2 != nil && v2.Ping() == nil {
+			return v2, nil
+		} else {
+			err1 = v2.Ping()
+		}
 	}
 
 	hub, err2 := NewDockerHubRegistry(url, org, username, password)
-	if err2 == nil && hub != nil && hub.Ping() == nil {
-		return hub, nil
+	if err2 == nil {
+		if hub != nil && hub.Ping() == nil {
+			return hub, nil
+		} else {
+			err2 = hub.Ping()
+		}
 	}
 
 	yard, err3 := NewContainerYardRegistry(url, org, username, password)
-	if err3 == nil && yard != nil && yard.Ping() == nil {
-		return yard, nil
+	if err3 == nil {
+		if yard != nil && yard.Ping() == nil {
+			return yard, nil
+		} else {
+			err3 = yard.Ping()
+		}
 	}
 
-	return nil, err1
+	msg := fmt.Sprintf("ERROR: Could not create registry. \n V2: %s \n docker hub: %s \n Container Yard: %s \n", err1.Error(), err2.Error(), err3.Error())
+	err := errors.New(msg)
+
+	return nil, err
 }

--- a/registry/RegistryFactory.go
+++ b/registry/RegistryFactory.go
@@ -16,6 +16,7 @@ type RepositoryRegistry interface {
 	Tags(repository, org string) ([]string, error)
 	Images(org string) ([]string, error)
 	ImagesWithManifests(org string) ([]objects.Image, error)
+	GetImageManifest(image, org string) (string, error)
 }
 
 type RepoRegistryFactory func(url, username, password string) (RepositoryRegistry, error)
@@ -45,11 +46,11 @@ func NewDockerHubRegistry(url, username, password string) (RepositoryRegistry, e
 }
 
 func NewContainerYardRegistry(url, username, password string) (RepositoryRegistry, error) {
-	yard, err := containeryard.New(url)
+	yard, err := containeryard.New(url, username, password)
 	if err != nil {
 		if strings.Contains(url, "https://") {
 			httpFallback := strings.Replace(url, "https://", "http://", 1)
-			yard, err = containeryard.New(httpFallback)
+			yard, err = containeryard.New(httpFallback, username, password)
 		}
 	}
 

--- a/registry/containeryard/registry.go
+++ b/registry/containeryard/registry.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"strings"
 
+	"github.com/heroku/docker-registry-client/registry"
 	"github.com/ngageoint/seed-common/util"
 )
 
@@ -12,6 +13,9 @@ import (
 type ContainerYardRegistry struct {
 	URL    string
 	Client *http.Client
+	Username string
+	Password string
+	v2Base *registry.Registry
 	Print  util.PrintCallback
 }
 
@@ -20,18 +24,23 @@ func (r *ContainerYardRegistry) Name() string {
 }
 
 //New creates a new docker hub registry from the given URL
-func New(registryUrl string) (*ContainerYardRegistry, error) {
+func New(registryUrl, username, password string) (*ContainerYardRegistry, error) {
 	if util.PrintUtil == nil {
 		util.InitPrinter(util.PrintErr)
 	}
 	url := strings.TrimSuffix(registryUrl, "/")
+	reg, err := registry.New(url, username, password)
+
 	registry := &ContainerYardRegistry{
 		URL:    url,
 		Client: &http.Client{},
+		Username: username,
+		Password: password,
+		v2Base: reg,
 		Print:  util.PrintUtil,
 	}
 
-	return registry, nil
+	return registry, err
 }
 
 func (r *ContainerYardRegistry) url(pathTemplate string, args ...interface{}) string {

--- a/registry/containeryard/registry.go
+++ b/registry/containeryard/registry.go
@@ -13,6 +13,7 @@ import (
 type ContainerYardRegistry struct {
 	URL    string
 	Client *http.Client
+	Org      string
 	Username string
 	Password string
 	v2Base *registry.Registry
@@ -24,7 +25,7 @@ func (r *ContainerYardRegistry) Name() string {
 }
 
 //New creates a new docker hub registry from the given URL
-func New(registryUrl, username, password string) (*ContainerYardRegistry, error) {
+func New(registryUrl, org, username, password string) (*ContainerYardRegistry, error) {
 	if util.PrintUtil == nil {
 		util.InitPrinter(util.PrintErr)
 	}
@@ -34,6 +35,7 @@ func New(registryUrl, username, password string) (*ContainerYardRegistry, error)
 	registry := &ContainerYardRegistry{
 		URL:    url,
 		Client: &http.Client{},
+		Org:      org,
 		Username: username,
 		Password: password,
 		v2Base: reg,

--- a/registry/containeryard/repositories.go
+++ b/registry/containeryard/repositories.go
@@ -146,9 +146,9 @@ func (registry *ContainerYardRegistry) GetImageManifest(repoName, tag string) (s
 	//password := registry.Password
 
 	manifest := ""
-	digest, err := registry.v2Base.ManifestDigest(repoName, tag)
+	mv2, err := registry.v2Base.ManifestV2(repoName, tag)
 	if err == nil {
-		resp, err := registry.v2Base.DownloadLayer(repoName, digest)
+		resp, err := registry.v2Base.DownloadLayer(repoName, mv2.Config.Digest)
 		if err == nil {
 			manifest, err = objects.GetSeedManifestFromBlob(resp)
 		}

--- a/registry/containeryard/repositories.go
+++ b/registry/containeryard/repositories.go
@@ -1,9 +1,10 @@
 package containeryard
 
 import (
+	"strings"
+	
 	"github.com/ngageoint/seed-common/objects"
 	"github.com/ngageoint/seed-common/util"
-	"strings"
 )
 
 type Response struct {

--- a/registry/containeryard/repositories.go
+++ b/registry/containeryard/repositories.go
@@ -105,7 +105,6 @@ func (registry *ContainerYardRegistry) ImagesWithManifests() ([]objects.Image, e
 			for name, value := range image.Labels {
 				if name == "com.ngageoint.seed.manifest" {
 					manifestLabel = util.UnescapeManifestLabel(value)
-					manifestLabel = manifestLabel[1:len(manifestLabel)-1]
 				}
 			}
 			if manifestLabel == "" {
@@ -123,7 +122,6 @@ func (registry *ContainerYardRegistry) ImagesWithManifests() ([]objects.Image, e
 			for name, value := range image.Labels {
 				if name == "com.ngageoint.seed.manifest" {
 					manifestLabel = util.UnescapeManifestLabel(value)
-					manifestLabel = manifestLabel[1:len(manifestLabel)-1]
 				}
 			}
 			if manifestLabel == "" {

--- a/registry/containeryard/repositories.go
+++ b/registry/containeryard/repositories.go
@@ -1,8 +1,6 @@
 package containeryard
 
 import (
-	"strings"
-	
 	"github.com/ngageoint/seed-common/objects"
 	"github.com/ngageoint/seed-common/util"
 )
@@ -140,12 +138,6 @@ func (registry *ContainerYardRegistry) ImagesWithManifests() ([]objects.Image, e
 }
 
 func (registry *ContainerYardRegistry) GetImageManifest(repoName, tag string) (string, error) {
-	//remove http(s) prefix for docker pull command
-	url := strings.Replace(registry.URL, "http://", "", 1)
-	url = strings.Replace(url, "https://", "", 1)
-	//username := registry.Username
-	//password := registry.Password
-
 	manifest := ""
 	mv2, err := registry.v2Base.ManifestV2(repoName, tag)
 	if err == nil {
@@ -155,19 +147,5 @@ func (registry *ContainerYardRegistry) GetImageManifest(repoName, tag string) (s
 		}
 	}
 
-	// falling back to docker pull may result in lots of large pulls for non-seed images that somehow snuck through,
-	// always slowing down scans
-	/*if err != nil {
-		// fallback to docker pull
-		registry.Print("ERROR: Could not get seed manifest from v2 API: %s\n", err.Error())
-		registry.Print("Falling back to docker pull\n")
-		imageName, err := util.DockerPull(image, url, r.Org, username, password)
-		if err == nil {
-			manifest, err = util.GetSeedManifestFromImage(imageName)
-		}
-		if err != nil {
-			registry.Print("ERROR: Could not get manifest: %s\n", err.Error())
-		}
-	}*/
 	return manifest, err
 }

--- a/registry/dockerhub/registry.go
+++ b/registry/dockerhub/registry.go
@@ -14,11 +14,12 @@ import (
 type DockerHubRegistry struct {
 	URL    string
 	Client *http.Client
+	Org    string
 	Print  util.PrintCallback
 }
 
 //New creates a new docker hub registry from the given URL
-func New(registryUrl string) (*DockerHubRegistry, error) {
+func New(registryUrl, org string) (*DockerHubRegistry, error) {
 	if util.PrintUtil == nil {
 		util.InitPrinter(util.PrintErr)
 	}
@@ -26,6 +27,7 @@ func New(registryUrl string) (*DockerHubRegistry, error) {
 	registry := &DockerHubRegistry{
 		URL:    url,
 		Client: &http.Client{},
+		Org:    org,
 		Print:  util.PrintUtil,
 	}
 

--- a/registry/dockerhub/repositories.go
+++ b/registry/dockerhub/repositories.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/ngageoint/seed-common/objects"
 	"github.com/ngageoint/seed-common/util"
-	"github.com/ngageoint/seed-common/registry/v2"
 )
 
 type repositoriesResponse struct {
@@ -21,7 +20,8 @@ type Result struct {
 }
 
 //Repositories Returns seed repositories for the given user/organization
-func (registry *DockerHubRegistry) Repositories(user string) ([]string, error) {
+func (registry *DockerHubRegistry) Repositories() ([]string, error) {
+	user := registry.Org
 	url := registry.url("/v2/repositories/%s/", user)
 	repos := make([]string, 0, 10)
 	var err error //We create this here, otherwise url will be rescoped with :=
@@ -43,7 +43,8 @@ func (registry *DockerHubRegistry) Repositories(user string) ([]string, error) {
 }
 
 //Tags Returns tags for a given user/organization and repository
-func (registry *DockerHubRegistry) Tags(user, repository string) ([]string, error) {
+func (registry *DockerHubRegistry) Tags(repository string) ([]string, error) {
+	user := registry.Org
 	url := registry.url("/v2/repositories/%s/%s/tags", user, repository)
 	tags := make([]string, 0, 10)
 	var err error //We create this here, otherwise url will be rescoped with :=
@@ -63,8 +64,8 @@ func (registry *DockerHubRegistry) Tags(user, repository string) ([]string, erro
 
 //Images returns seed images for a given user/repository.  It will grab all of the seed repositories and combine them
 //with any tags it can find to build a list of images.
-func (registry *DockerHubRegistry) Images(user string) ([]string, error) {
-	url := registry.url("/v2/repositories/%s/", user)
+func (registry *DockerHubRegistry) Images() ([]string, error) {
+	url := registry.url("/v2/repositories/%s/", registry.Org)
 	registry.Print("Searching %s for Seed images...\n", url)
 	repos := make([]string, 0, 10)
 	var err error //We create this here, otherwise url will be rescoped with :=
@@ -77,7 +78,7 @@ func (registry *DockerHubRegistry) Images(user string) ([]string, error) {
 				continue
 			}
 			// Add all tags if found
-			if rs, _ := registry.Tags(user, r.Name); len(rs) > 0 {
+			if rs, _ := registry.Tags(r.Name); len(rs) > 0 {
 				for _, tag := range rs {
 					img := r.Name + ":" + tag
 					repos = append(repos, img)
@@ -94,8 +95,8 @@ func (registry *DockerHubRegistry) Images(user string) ([]string, error) {
 	return repos, nil
 }
 
-func (registry *DockerHubRegistry) ImagesWithManifests(org string) ([]objects.Image, error) {
-	imageNames, err := registry.Images(org)
+func (registry *DockerHubRegistry) ImagesWithManifests() ([]objects.Image, error) {
+	imageNames, err := registry.Images()
 
 	if err != nil {
 		return nil, err
@@ -104,23 +105,28 @@ func (registry *DockerHubRegistry) ImagesWithManifests(org string) ([]objects.Im
 	images := []objects.Image{}
 
 	url := "docker.io"
-	username := ""
-	password := ""
 
+	manifest := ""
 	for _, imgstr := range imageNames {
-		manifest := GetImageManifest(imgstr, org)
+		temp := strings.Split(imgstr, ":")
+		if len(temp) != 2 {
+			registry.Print("ERROR: Invalid seed name: %s. Unable to split into name/tag pair\n", imgstr)
+			continue
+		}
+		manifest, err = registry.GetImageManifest(temp[0], temp[1])
 
-		imageStruct := objects.Image{Name: imgstr, Registry: url, Org: org, Manifest: manifest}
+		imageStruct := objects.Image{Name: imgstr, Registry: url, Org: registry.Org, Manifest: manifest}
 		images = append(images, imageStruct)
 	}
 
 	return images, err
 }
 
-func (registry *DockerHubRegistry) GetImageManifest(image, org string) (string, error) {
+func (registry *DockerHubRegistry) GetImageManifest(repoName, tag string) (string, error) {
 	manifest := ""
 	//TODO: find better, lightweight way to get manifest on low side
-	imageName, err := util.DockerPull(image, "docker.io", org, "", "")
+	image := repoName + ":" + tag
+	imageName, err := util.DockerPull(image, "docker.io", registry.Org, "", "")
 	if err == nil {
 		manifest, err = util.GetSeedManifestFromImage(imageName)
 	}

--- a/registry/dockerhub/repositories.go
+++ b/registry/dockerhub/repositories.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/ngageoint/seed-common/objects"
 	"github.com/ngageoint/seed-common/util"
+	"github.com/ngageoint/seed-common/registry/v2"
 )
 
 type repositoriesResponse struct {
@@ -107,19 +108,24 @@ func (registry *DockerHubRegistry) ImagesWithManifests(org string) ([]objects.Im
 	password := ""
 
 	for _, imgstr := range imageNames {
-		manifest := ""
-		//TODO: find better, lightweight way to get manifest on low side
-		imageName, err := util.DockerPull(imgstr, url, org, username, password)
-		if err == nil {
-			manifest, err = util.GetSeedManifestFromImage(imageName)
-		}
-		if err != nil {
-			registry.Print("ERROR: Could not get manifest: %s\n", err.Error())
-		}
+		manifest := GetImageManifest(imgstr, org)
 
 		imageStruct := objects.Image{Name: imgstr, Registry: url, Org: org, Manifest: manifest}
 		images = append(images, imageStruct)
 	}
 
 	return images, err
+}
+
+func (registry *DockerHubRegistry) GetImageManifest(image, org string) (string, error) {
+	manifest := ""
+	//TODO: find better, lightweight way to get manifest on low side
+	imageName, err := util.DockerPull(image, "docker.io", org, "", "")
+	if err == nil {
+		manifest, err = util.GetSeedManifestFromImage(imageName)
+	}
+	if err != nil {
+		registry.Print("ERROR: Could not get manifest: %s\n", err.Error())
+	}
+	return manifest, err
 }

--- a/registry/v2/registry.go
+++ b/registry/v2/registry.go
@@ -28,36 +28,36 @@ func New(url, org, username, password string) (*v2registry, error) {
 	return nil, err
 }
 
-func (r *v2registry) Name() string {
+func (v2 *v2registry) Name() string {
 	return "V2"
 }
 
-func (r *v2registry) Ping() error {
-	_, err := r.r.Repositories()
+func (v2 *v2registry) Ping() error {
+	_, err := v2.r.Repositories()
 	return err
 }
 
-func (r *v2registry) Repositories() ([]string, error) {
-	return r.r.Repositories()
+func (v2 *v2registry) Repositories() ([]string, error) {
+	return v2.r.Repositories()
 }
 
-func (r *v2registry) Tags(repository string) ([]string, error) {
-	return r.r.Tags(repository)
+func (v2 *v2registry) Tags(repository string) ([]string, error) {
+	return v2.r.Tags(repository)
 }
 
-func (r *v2registry) Images() ([]string, error) {
-	url := r.r.URL + "/v2/_catalog"
-	r.Print("Searching %s for Seed images...\n", url)
-	repositories, err := r.r.Repositories()
+func (v2 *v2registry) Images() ([]string, error) {
+	url := v2.r.URL + "/v2/_catalog"
+	v2.Print("Searching %s for Seed images...\n", url)
+	repositories, err := v2.r.Repositories()
 
 	var images []string
 	for _, repo := range repositories {
 		if !strings.HasSuffix(repo, "-seed") {
 			continue
 		}
-		tags, err := r.Tags(repo)
+		tags, err := v2.Tags(repo)
 		if err != nil {
-			r.Print(err.Error())
+			v2.Print(err.Error())
 			continue
 		}
 		for _, tag := range tags {
@@ -68,8 +68,8 @@ func (r *v2registry) Images() ([]string, error) {
 	return images, err
 }
 
-func (r *v2registry) ImagesWithManifests() ([]objects.Image, error) {
-	imageNames, err := r.Images()
+func (v2 *v2registry) ImagesWithManifests() ([]objects.Image, error) {
+	imageNames, err := v2.Images()
 
 	if err != nil {
 		return nil, err
@@ -80,28 +80,28 @@ func (r *v2registry) ImagesWithManifests() ([]objects.Image, error) {
 	for _, imgstr := range imageNames {
 		temp := strings.Split(imgstr, ":")
 		if len(temp) != 2 {
-			r.Print("ERROR: Invalid seed name: %s. Unable to split into name/tag pair\n", imgstr)
+			v2.Print("ERROR: Invalid seed name: %s. Unable to split into name/tag pair\n", imgstr)
 			continue
 		}
-		manifest, err := r.GetImageManifest(temp[0], temp[1])
+		manifest, err := v2.GetImageManifest(temp[0], temp[1])
 		if err != nil {
 			//skip images with empty manifests
-			r.Print("ERROR: Error reading v2 manifest for %s: %s\n Skipping.\n", imgstr, err.Error())
+			v2.Print("ERROR: Error reading v2 manifest for %s: %s\n Skipping.\n", imgstr, err.Error())
 			continue
 		}
 
-		imageStruct := objects.Image{Name: imgstr, Registry: r.r.URL, Org: r.Org, Manifest: manifest}
+		imageStruct := objects.Image{Name: imgstr, Registry: v2.r.URL, Org: v2.Org, Manifest: manifest}
 		images = append(images, imageStruct)
 	}
 
 	return images, err
 }
 
-func (r *v2registry) GetImageManifest(repoName, tag string) (string, error) {
+func (v2 *v2registry) GetImageManifest(repoName, tag string) (string, error) {
 	manifest := ""
-	mv2, err := r.r.ManifestV2(repoName, tag)
+	mv2, err := v2.r.ManifestV2(repoName, tag)
 	if err == nil {
-		resp, err := r.r.DownloadLayer(repoName, mv2.Config.Digest)
+		resp, err := v2.r.DownloadLayer(repoName, mv2.Config.Digest)
 		if err == nil {
 			manifest, err = objects.GetSeedManifestFromBlob(resp)
 		}

--- a/registry/v2/registry.go
+++ b/registry/v2/registry.go
@@ -10,19 +10,20 @@ import (
 
 type v2registry struct {
 	r        *registry.Registry
+	Org      string
 	Username string
 	Password string
 	Print    util.PrintCallback
 }
 
-func New(url, username, password string) (*v2registry, error) {
+func New(url, org, username, password string) (*v2registry, error) {
 	if util.PrintUtil == nil {
 		util.InitPrinter(util.PrintErr)
 	}
 
 	reg, err := registry.New(url, username, password)
 	if reg != nil {
-		return &v2registry{r: reg, Username: username, Password: password, Print: util.PrintUtil}, err
+		return &v2registry{r: reg, Org: org, Username: username, Password: password, Print: util.PrintUtil}, err
 	}
 	return nil, err
 }
@@ -36,15 +37,15 @@ func (r *v2registry) Ping() error {
 	return err
 }
 
-func (r *v2registry) Repositories(org string) ([]string, error) {
+func (r *v2registry) Repositories() ([]string, error) {
 	return r.r.Repositories()
 }
 
-func (r *v2registry) Tags(repository, org string) ([]string, error) {
+func (r *v2registry) Tags(repository string) ([]string, error) {
 	return r.r.Tags(repository)
 }
 
-func (r *v2registry) Images(org string) ([]string, error) {
+func (r *v2registry) Images() ([]string, error) {
 	url := r.r.URL + "/v2/_catalog"
 	r.Print("Searching %s for Seed images...\n", url)
 	repositories, err := r.r.Repositories()
@@ -54,7 +55,7 @@ func (r *v2registry) Images(org string) ([]string, error) {
 		if !strings.HasSuffix(repo, "-seed") {
 			continue
 		}
-		tags, err := r.Tags(repo, org)
+		tags, err := r.Tags(repo)
 		if err != nil {
 			r.Print(err.Error())
 			continue
@@ -67,8 +68,8 @@ func (r *v2registry) Images(org string) ([]string, error) {
 	return images, err
 }
 
-func (r *v2registry) ImagesWithManifests(org string) ([]objects.Image, error) {
-	imageNames, err := r.Images(org)
+func (r *v2registry) ImagesWithManifests() ([]objects.Image, error) {
+	imageNames, err := r.Images()
 
 	if err != nil {
 		return nil, err
@@ -77,41 +78,53 @@ func (r *v2registry) ImagesWithManifests(org string) ([]objects.Image, error) {
 	images := []objects.Image{}
 
 	for _, imgstr := range imageNames {
-		manifest, err := r.GetImageManifest(imgstr, org)
+		temp := strings.Split(imgstr, ":")
+		if len(temp) != 2 {
+			r.Print("ERROR: Invalid seed name: %s. Unable to split into name/tag pair\n", imgstr)
+			continue
+		}
+		manifest, err := r.GetImageManifest(temp[0], temp[1])
 		if err != nil {
 			//skip images with empty manifests
+			r.Print("ERROR: Error reading v2 manifest for %s: %s\n Skipping.\n", imgstr, err.Error())
 			continue
 		}
 
-		imageStruct := objects.Image{Name: imgstr, Registry: r.r.URL, Org: org, Manifest: manifest}
+		imageStruct := objects.Image{Name: imgstr, Registry: r.r.URL, Org: r.Org, Manifest: manifest}
 		images = append(images, imageStruct)
 	}
 
 	return images, err
 }
 
-func (r *v2registry) GetImageManifest(image, tag string) (string, error) {
+func (r *v2registry) GetImageManifest(repoName, tag string) (string, error) {
 	//remove http(s) prefix for docker pull command
 	url := strings.Replace(r.r.URL, "http://", "", 1)
 	url = strings.Replace(url, "https://", "", 1)
-	username := r.Username
-	password := r.Password
+	//username := r.Username
+	//password := r.Password
 
-	digest, err := r.r.ManifestDigest(image, tag)
+	manifest := ""
+	digest, err := r.r.ManifestDigest(repoName, tag)
 	if err == nil {
-		resp, err := r.r.DownloadLayer(image, digest)
+		resp, err := r.r.DownloadLayer(repoName, digest)
 		if err == nil {
-
+			manifest, err = objects.GetSeedManifestFromBlob(resp)
 		}
 	}
-	manifest := ""
-	//TODO: find better, lightweight way to get manifest on low side
-	imageName, err := util.DockerPull(image, url, org, username, password)
-	if err == nil {
-		manifest, err = util.GetSeedManifestFromImage(imageName)
-	}
-	if err != nil {
-		r.Print("ERROR: Could not get manifest: %s\n", err.Error())
-	}
+
+	/*if err != nil {
+		// fallback to docker pull
+		r.Print("ERROR: Could not get seed manifest from v2 API: %s\n", err.Error())
+		r.Print("Falling back to docker pull\n")
+		imageName, err := util.DockerPull(image, url, r.Org, username, password)
+		if err == nil {
+			manifest, err = util.GetSeedManifestFromImage(imageName)
+		}
+		if err != nil {
+			r.Print("ERROR: Could not get manifest: %s\n", err.Error())
+		}
+	}*/
+
 	return manifest, err
 }

--- a/registry/v2/registry.go
+++ b/registry/v2/registry.go
@@ -99,15 +99,15 @@ func (r *v2registry) ImagesWithManifests() ([]objects.Image, error) {
 
 func (r *v2registry) GetImageManifest(repoName, tag string) (string, error) {
 	//remove http(s) prefix for docker pull command
-	url := strings.Replace(r.r.URL, "http://", "", 1)
-	url = strings.Replace(url, "https://", "", 1)
+	//url := strings.Replace(r.r.URL, "http://", "", 1)
+	//url = strings.Replace(url, "https://", "", 1)
 	//username := r.Username
 	//password := r.Password
 
 	manifest := ""
-	digest, err := r.r.ManifestDigest(repoName, tag)
+	mv2, err := r.r.ManifestV2(repoName, tag)
 	if err == nil {
-		resp, err := r.r.DownloadLayer(repoName, digest)
+		resp, err := r.r.DownloadLayer(repoName, mv2.Config.Digest)
 		if err == nil {
 			manifest, err = objects.GetSeedManifestFromBlob(resp)
 		}

--- a/registry/v2/registry.go
+++ b/registry/v2/registry.go
@@ -98,12 +98,6 @@ func (r *v2registry) ImagesWithManifests() ([]objects.Image, error) {
 }
 
 func (r *v2registry) GetImageManifest(repoName, tag string) (string, error) {
-	//remove http(s) prefix for docker pull command
-	//url := strings.Replace(r.r.URL, "http://", "", 1)
-	//url = strings.Replace(url, "https://", "", 1)
-	//username := r.Username
-	//password := r.Password
-
 	manifest := ""
 	mv2, err := r.r.ManifestV2(repoName, tag)
 	if err == nil {
@@ -112,19 +106,6 @@ func (r *v2registry) GetImageManifest(repoName, tag string) (string, error) {
 			manifest, err = objects.GetSeedManifestFromBlob(resp)
 		}
 	}
-
-	/*if err != nil {
-		// fallback to docker pull
-		r.Print("ERROR: Could not get seed manifest from v2 API: %s\n", err.Error())
-		r.Print("Falling back to docker pull\n")
-		imageName, err := util.DockerPull(image, url, r.Org, username, password)
-		if err == nil {
-			manifest, err = util.GetSeedManifestFromImage(imageName)
-		}
-		if err != nil {
-			r.Print("ERROR: Could not get manifest: %s\n", err.Error())
-		}
-	}*/
 
 	return manifest, err
 }

--- a/util/seed_strings.go
+++ b/util/seed_strings.go
@@ -12,5 +12,9 @@ func UnescapeManifestLabel(label string) string {
 	seedStr = strings.TrimSpace(seedStr)
 	seedStr = strings.TrimSuffix(strings.TrimPrefix(seedStr, "'\""), "\"'")
 
+	if seedStr[0] == '"' {  //fix quoted string
+		seedStr = seedStr[1:len(seedStr)-1]
+	}
+
 	return seedStr
 }


### PR DESCRIPTION
Changes to the seed common library to get seed manifests from the docker v2 registry api instead of pulling the images.