### PR TITLE
Populating org for container yard images

### DIFF
--- a/constants/constants.go
+++ b/constants/constants.go
@@ -39,6 +39,12 @@ const InputsFlag = "inputs"
 //ShortInputsFlag defines the shorthand input flag
 const ShortInputsFlag = "i"
 
+//InputsFlag defines the InputFlag
+const JsonFlag = "json"
+
+//ShortInputsFlag defines the shorthand input flag
+const ShortJsonFlag = "j"
+
 //JobOutputDirFlag defines the job output directory
 const JobOutputDirFlag = "outDir"
 

--- a/registry/containeryard/registry.go
+++ b/registry/containeryard/registry.go
@@ -11,13 +11,14 @@ import (
 
 //ContainerYardRegistry type representing a Container Yard registry
 type ContainerYardRegistry struct {
-	URL    string
-	Client *http.Client
+	URL      string
+	Hostname string
+	Client   *http.Client
 	Org      string
 	Username string
 	Password string
-	v2Base *registry.Registry
-	Print  util.PrintCallback
+	v2Base   *registry.Registry
+	Print    util.PrintCallback
 }
 
 func (r *ContainerYardRegistry) Name() string {
@@ -32,14 +33,18 @@ func New(registryUrl, org, username, password string) (*ContainerYardRegistry, e
 	url := strings.TrimSuffix(registryUrl, "/")
 	reg, err := registry.New(url, username, password)
 
+	host := strings.Replace(url, "https://", "", 1)
+	host = strings.Replace(host, "http://", "", 1)
+
 	registry := &ContainerYardRegistry{
-		URL:    url,
-		Client: &http.Client{},
+		URL:      url,
+		Hostname: host,
+		Client:   &http.Client{},
 		Org:      org,
 		Username: username,
 		Password: password,
-		v2Base: reg,
-		Print:  util.PrintUtil,
+		v2Base:   reg,
+		Print:    util.PrintUtil,
 	}
 
 	return registry, err

--- a/registry/containeryard/repositories.go
+++ b/registry/containeryard/repositories.go
@@ -2,7 +2,7 @@ package containeryard
 
 import (
 	"strings"
-	
+
 	"github.com/ngageoint/seed-common/objects"
 	"github.com/ngageoint/seed-common/util"
 )
@@ -117,7 +117,15 @@ func (registry *ContainerYardRegistry) ImagesWithManifests() ([]objects.Image, e
 			for tagName, _ := range image.Tags {
 				manifestLabel, err = registry.GetImageManifest(repoName, tagName)
 				imageStr := repoName + ":" + tagName
-				img := objects.Image{Name: imageStr, Registry: registry.URL, Org: registry.Org, Manifest: manifestLabel}
+				org := registry.Org
+				parts := strings.SplitN(imageStr, "/",2)
+				if len(parts) == 2 {
+					org = parts[0]
+					imageStr = parts[1]
+				} else {
+					registry.Print("Error parsing org out of repo name: %s \n", repoName)
+				}
+				img := objects.Image{Name: imageStr, Registry: registry.Hostname, Org: org, Manifest: manifestLabel}
 				repos = append(repos, img)
 			}
 		}
@@ -137,7 +145,15 @@ func (registry *ContainerYardRegistry) ImagesWithManifests() ([]objects.Image, e
 			for tagName, _ := range image.Tags {
 				manifestLabel, err = registry.GetImageManifest(repoName, tagName)
 				imageStr := repoName + ":" + tagName
-				img := objects.Image{Name: imageStr, Registry: registry.URL, Org: registry.Org, Manifest: manifestLabel}
+				org := registry.Org
+				parts := strings.SplitN(imageStr, "/",2)
+				if len(parts) == 2 {
+					org = parts[0]
+					imageStr = parts[1]
+				} else {
+					registry.Print("Error parsing org out of repo name: %s \n", repoName)
+				}
+				img := objects.Image{Name: imageStr, Registry: registry.Hostname, Org: org, Manifest: manifestLabel}
 				repos = append(repos, img)
 			}
 		}

--- a/registry/registry_test.go
+++ b/registry/registry_test.go
@@ -170,7 +170,7 @@ func TestImagesWithManifests(t *testing.T) {
 		errStr        string
 	}{
 		{0, "[addition-job-0.0.1-seed:1.0.0 extractor-0.1.0-seed:0.1.0 my-job-0.1.0-seed:0.1.0 my-job-0.1.2-seed:2.0.0 my-job-1.0.0-seed:0.1.0]", "geointseed", "docker.io", ""},
-		{1, "[my-job-0.1.0-seed:0.1.0]", "", "http://localhost:5000", ""},
+		{1, "[my-job-0.1.0-seed:0.1.0]", "", "localhost:5000", ""},
 		{2, "[]", "geointseed-typo", "docker.io", ""},
 	}
 

--- a/registry/registry_test.go
+++ b/registry/registry_test.go
@@ -212,10 +212,6 @@ func TestImagesWithManifests(t *testing.T) {
 		if err == nil && c.expectedNames != resultStr {
 			t.Errorf("ImagesWithManifests returned %v, expected %v\n", resultStr, c.expectedNames)
 		}
-		if err == nil && c.expectedNames != resultStr {
-			t.Errorf("ImagesWithManifests returned %v, expected %v\n", resultStr, c.expectedNames)
-		}
-
 		if err != nil && !strings.Contains(err.Error(), c.errStr) {
 			t.Errorf("ImagesWithManifests returned an error: %v\n expected %v", err, c.errStr)
 		}

--- a/registry/v2/registry.go
+++ b/registry/v2/registry.go
@@ -10,6 +10,7 @@ import (
 
 type v2registry struct {
 	r        *registry.Registry
+	Hostname string
 	Org      string
 	Username string
 	Password string
@@ -23,7 +24,9 @@ func New(url, org, username, password string) (*v2registry, error) {
 
 	reg, err := registry.New(url, username, password)
 	if reg != nil {
-		return &v2registry{r: reg, Org: org, Username: username, Password: password, Print: util.PrintUtil}, err
+		host := strings.Replace(url, "https://", "", 1)
+		host = strings.Replace(host, "http://", "", 1)
+		return &v2registry{r: reg, Hostname: host, Org: org, Username: username, Password: password, Print: util.PrintUtil}, err
 	}
 	return nil, err
 }
@@ -90,7 +93,7 @@ func (v2 *v2registry) ImagesWithManifests() ([]objects.Image, error) {
 			continue
 		}
 
-		imageStruct := objects.Image{Name: imgstr, Registry: v2.r.URL, Org: v2.Org, Manifest: manifest}
+		imageStruct := objects.Image{Name: imgstr, Registry: v2.Hostname, Org: v2.Org, Manifest: manifest}
 		images = append(images, imageStruct)
 	}
 

--- a/testdata/complete/seed.manifest.json
+++ b/testdata/complete/seed.manifest.json
@@ -77,7 +77,7 @@
     },
     "resources": {
       "scalar": [
-        { "name": "cpu", "value": 10.0 },
+        { "name": "cpus", "value": 10.0 },
         { "name": "mem", "value": 10240.0 },
         { "name": "sharedMem", "value": 0.0 },
         { "name": "disk", "value": 10.0, "inputMultiplier": 4.0 }

--- a/util/seed_strings_test.go
+++ b/util/seed_strings_test.go
@@ -50,7 +50,7 @@ func TestParseSeedImageName(t *testing.T) {
 		}
 
 		if err == nil && c.errStr != "" {
-			t.Errorf("ParseSeedImageName(%q) did not return an error when one was expected", resultStr, c.output)
+			t.Errorf("ParseSeedImageName(%q) did not return an error when one was expected", resultStr)
 		}
 
 		if err != nil && !strings.Contains(err.Error(), c.errStr) {

--- a/util/variable_test.go
+++ b/util/variable_test.go
@@ -43,7 +43,7 @@ func TestIsReserved(t *testing.T) {
 	for _, c := range cases {
 		reserved := IsReserved(c.name, c.allocated)
 		if reserved != c.reserved {
-			t.Errorf("IsReserved(%q, %q) returned %s, expected %s", c.name, c.allocated, reserved, c.reserved)
+			t.Errorf("IsReserved(%v, %v) returned %v, expected %v", c.name, c.allocated, reserved, c.reserved)
 		}
 	}
 }
@@ -64,7 +64,7 @@ func TestIsInUse(t *testing.T) {
 	for _, c := range cases {
 		used := IsInUse(c.name, c.path, vars)
 		if used != c.in_use {
-			t.Errorf("IsInUse(%q, %q, %q) returned %s, expected %s", c.name, c.path, vars, used, c.in_use)
+			t.Errorf("IsInUse(%v, %v, %v) returned %v, expected %v", c.name, c.path, vars, used, c.in_use)
 		}
 	}
 }
@@ -84,7 +84,7 @@ func TestRemoveString(t *testing.T) {
 		result := RemoveString(c.list, c.s)
 
 		if fmt.Sprintf("%s", result) != fmt.Sprintf("%s", c.result) {
-			t.Errorf("RemoveString(%q, %q) returned %s, expected %s", c.list, c.s, result, c.result)
+			t.Errorf("RemoveString(%v, %v) returned %v, expected %v", c.list, c.s, result, c.result)
 		}
 	}
 }
@@ -104,7 +104,7 @@ func TestContainsString(t *testing.T) {
 		result := ContainsString(c.list, c.s)
 
 		if result != c.result {
-			t.Errorf("RemoveString(%q, %q) returned %s, expected %s", c.list, c.s, result, c.result)
+			t.Errorf("RemoveString(%v, %v) returned %v, expected %v", c.list, c.s, result, c.result)
 		}
 	}
 }


### PR DESCRIPTION
Populating the org for container yard images and removing protocol from registry names (#4) and updating testdata to match cpus change in seed spec.