### PR TITLE
Reduce redundant messages

### DIFF
--- a/util/file.go
+++ b/util/file.go
@@ -2,6 +2,8 @@ package util
 
 import (
 	"bufio"
+	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -128,9 +130,9 @@ func GetSeedFileName(dir string) (string, bool, error) {
 func SeedFileName(dir string) (string, error) {
 	seedFileName, exists, err := GetSeedFileName(dir)
 	if !exists {
-		PrintUtil("ERROR: %s cannot be found.\n",
-			seedFileName)
-		PrintUtil("Make sure you have specified the correct directory.\n")
+		msg := fmt.Sprintf("ERROR: %s cannot be found. Make sure you "+
+			"have specified the correct directory.\n", seedFileName)
+		err = errors.New(msg)
 	}
 
 	return seedFileName, err

--- a/util/file_test.go
+++ b/util/file_test.go
@@ -1,4 +1,4 @@
-	package util
+package util
 
 import (
 	"fmt"

--- a/util/file_test.go
+++ b/util/file_test.go
@@ -1,4 +1,4 @@
-package util
+	package util
 
 import (
 	"fmt"
@@ -65,7 +65,7 @@ func TestReadLinesFromFile(t *testing.T) {
 		lineCount int
 		errorMsg  string
 	}{
-		{".", 0, "no such file or directory"},
+		{".", 0, "seed.manifest.json cannot be found"},
 		{"../testdata/complete", 101, ""},
 	}
 
@@ -87,7 +87,7 @@ func TestReadLinesFromFile(t *testing.T) {
 			errMsg = fmt.Sprintf("%s", err.Error())
 		}
 		if !strings.Contains(errMsg, c.errorMsg) {
-			t.Errorf("DockerfileBaseRegistry(%q) == %v, expected %v", c.dir, errMsg, c.errorMsg)
+			t.Errorf("TestReadLinesFromFile(%q) == %v, expected %v", c.dir, errMsg, c.errorMsg)
 		}
 	}
 }


### PR DESCRIPTION
Return an error and let the caller decide how to handle it rather than both printing the error and returning it.