### PR TITLE
Special Character Handling

### DIFF
--- a/objects/Seed.go
+++ b/objects/Seed.go
@@ -8,7 +8,7 @@ import (
 	"os"
 	"os/exec"
 	"strconv"
-	// "strings"
+	"strings"
 
 	"github.com/ngageoint/seed-common/constants"
 	"github.com/ngageoint/seed-common/util"

--- a/objects/Seed.go
+++ b/objects/Seed.go
@@ -213,12 +213,10 @@ func GetManifestLabel(seedFileName string) string {
 			err.Error())
 	}
 
-	util.PrintUtil("GetManifestLabel.seedbytes:\n%s\n", string(seedbytes))
-
 	// Escape forward slashes and dollar signs
 	seed := string(seedbytes)
-	// seed = strings.Replace(seed, "$", "\\$", -1)
-	// seed = strings.Replace(seed, "/", "\\\\/", -1)
+	seed = strings.Replace(seed, "$", "\\$", -1)
+	seed = strings.Replace(seed, "/", "\\/", -1)
 
 	return seed
 }

--- a/objects/Seed.go
+++ b/objects/Seed.go
@@ -312,12 +312,10 @@ func SeedFromManifestFile(seedFileName string) Seed {
 func SeedFromManifestString(manifest string) (Seed, error) {
 	seed := &Seed{}
 
-	util.PrintUtil("SeedFromManifestString.manifest:\n%s\n", manifest)
 	manifest, err := strconv.Unquote(manifest)
 	if err != nil {
 		util.PrintUtil("ERROR: Error unquoting manifest: %s\n", err.Error())
 	}
-	util.PrintUtil("Unquoted manifest:\n%s\nUnmarshalling....", manifest)
 	err = json.Unmarshal([]byte(manifest), &seed)
 	if err != nil {
 		util.PrintUtil("ERROR: Error unmarshalling seed: %s\n", err.Error())

--- a/objects/Seed.go
+++ b/objects/Seed.go
@@ -7,7 +7,8 @@ import (
 	"io/ioutil"
 	"os"
 	"os/exec"
-	"strings"
+	"strconv"
+	// "strings"
 
 	"github.com/ngageoint/seed-common/constants"
 	"github.com/ngageoint/seed-common/util"
@@ -212,10 +213,12 @@ func GetManifestLabel(seedFileName string) string {
 			err.Error())
 	}
 
+	util.PrintUtil("GetManifestLabel.seedbytes:\n%s\n", string(seedbytes))
+
 	// Escape forward slashes and dollar signs
 	seed := string(seedbytes)
-	seed = strings.Replace(seed, "$", "\\$", -1)
-	seed = strings.Replace(seed, "/", "\\/", -1)
+	// seed = strings.Replace(seed, "$", "\\$", -1)
+	// seed = strings.Replace(seed, "/", "\\\\/", -1)
 
 	return seed
 }
@@ -309,7 +312,13 @@ func SeedFromManifestFile(seedFileName string) Seed {
 func SeedFromManifestString(manifest string) (Seed, error) {
 	seed := &Seed{}
 
-	err := json.Unmarshal([]byte(manifest), &seed)
+	util.PrintUtil("SeedFromManifestString.manifest:\n%s\n", manifest)
+	manifest, err := strconv.Unquote(manifest)
+	if err != nil {
+		util.PrintUtil("ERROR: Error unquoting manifest: %s\n", err.Error())
+	}
+	util.PrintUtil("Unquoted manifest:\n%s\nUnmarshalling....", manifest)
+	err = json.Unmarshal([]byte(manifest), &seed)
 	if err != nil {
 		util.PrintUtil("ERROR: Error unmarshalling seed: %s\n", err.Error())
 	}

--- a/objects/Seed.go
+++ b/objects/Seed.go
@@ -310,6 +310,9 @@ func SeedFromManifestFile(seedFileName string) Seed {
 func SeedFromManifestString(manifest string) (Seed, error) {
 	seed := &Seed{}
 
+	// unescape special characters 
+	manifest = strings.Replace(manifest, "\\$", "$", -1)
+	manifest = strings.Replace(manifest, "\\/", "/", -1)
 	manifest, err := strconv.Unquote(manifest)
 	if err != nil {
 		util.PrintUtil("ERROR: Error unquoting manifest: %s\n", err.Error())


### PR DESCRIPTION
Unescapes the special characters, then 'unquotes' the manifest string before unmarshalling when retrieving the manifest from a string. Addresses the issue when an odd number of apostrophes were present in the manifest. See [Seed CLI #178](https://github.com/ngageoint/seed-cli/issues/178)