### PR TITLE
Fix docker hub

### DIFF
--- a/registry/RegistryFactory.go
+++ b/registry/RegistryFactory.go
@@ -36,11 +36,11 @@ func NewV2Registry(url, org, username, password string) (RepositoryRegistry, err
 }
 
 func NewDockerHubRegistry(url, org, username, password string) (RepositoryRegistry, error) {
-	hub, err := dockerhub.New(url, org)
+	hub, err := dockerhub.New(url, org, username, password)
 	if err != nil {
 		if strings.Contains(url, "https://") {
 			httpFallback := strings.Replace(url, "https://", "http://", 1)
-			hub, err = dockerhub.New(httpFallback, org)
+			hub, err = dockerhub.New(httpFallback, org, username, password)
 		}
 	}
 

--- a/registry/dockerhub/registry.go
+++ b/registry/dockerhub/registry.go
@@ -27,13 +27,13 @@ func New(registryUrl, org, username, password string) (*DockerHubRegistry, error
 	}
 	url := strings.TrimSuffix(registryUrl, "/")
 
-	reg, _ := registry.New("https://registry-1.docker.io", username, password)
+	reg, _ := registry.New("https://registry-1.docker.io/", username, password)
 
 	registry := &DockerHubRegistry{
 		URL:    url,
 		Client: &http.Client{},
 		Org:    org,
-		v2Base:   reg,
+		v2Base: reg,
 		Print:  util.PrintUtil,
 	}
 

--- a/registry/dockerhub/registry.go
+++ b/registry/dockerhub/registry.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"strings"
 
+	"github.com/heroku/docker-registry-client/registry"
 	"github.com/ngageoint/seed-common/constants"
 	"github.com/ngageoint/seed-common/util"
 )
@@ -15,19 +16,24 @@ type DockerHubRegistry struct {
 	URL    string
 	Client *http.Client
 	Org    string
+	v2Base *registry.Registry
 	Print  util.PrintCallback
 }
 
 //New creates a new docker hub registry from the given URL
-func New(registryUrl, org string) (*DockerHubRegistry, error) {
+func New(registryUrl, org, username, password string) (*DockerHubRegistry, error) {
 	if util.PrintUtil == nil {
 		util.InitPrinter(util.PrintErr)
 	}
 	url := strings.TrimSuffix(registryUrl, "/")
+
+	reg, _ := registry.New("https://registry-1.docker.io", username, password)
+
 	registry := &DockerHubRegistry{
 		URL:    url,
 		Client: &http.Client{},
 		Org:    org,
+		v2Base:   reg,
 		Print:  util.PrintUtil,
 	}
 

--- a/registry/dockerhub/repositories.go
+++ b/registry/dockerhub/repositories.go
@@ -125,10 +125,10 @@ func (registry *DockerHubRegistry) ImagesWithManifests() ([]objects.Image, error
 func (registry *DockerHubRegistry) GetImageManifest(repoName, tag string) (string, error) {
 	manifest := ""
 	mv2, err := registry.v2Base.ManifestV2(repoName, tag)
-	registry.Print(mv2)
+	registry.Print("manifest: %s\n", mv2)
 	if err == nil {
 		resp, err := registry.v2Base.DownloadLayer(repoName, mv2.Config.Digest)
-		registry.Print(resp)
+		registry.Print("response: %s\n", resp)
 		if err == nil {
 			manifest, err = objects.GetSeedManifestFromBlob(resp)
 		}

--- a/registry/dockerhub/repositories.go
+++ b/registry/dockerhub/repositories.go
@@ -124,10 +124,11 @@ func (registry *DockerHubRegistry) ImagesWithManifests() ([]objects.Image, error
 
 func (registry *DockerHubRegistry) GetImageManifest(repoName, tag string) (string, error) {
 	manifest := ""
-	mv2, err := registry.v2Base.ManifestV2(repoName, tag)
+	orgRepoName := registry.Org + "/" + repoName
+	mv2, err := registry.v2Base.ManifestV2(orgRepoName, tag)
 	registry.Print("manifest: %s\n", mv2)
 	if err == nil {
-		resp, err := registry.v2Base.DownloadLayer(repoName, mv2.Config.Digest)
+		resp, err := registry.v2Base.DownloadLayer(orgRepoName, mv2.Config.Digest)
 		registry.Print("response: %s\n", resp)
 		if err == nil {
 			manifest, err = objects.GetSeedManifestFromBlob(resp)

--- a/registry/dockerhub/repositories.go
+++ b/registry/dockerhub/repositories.go
@@ -126,10 +126,8 @@ func (registry *DockerHubRegistry) GetImageManifest(repoName, tag string) (strin
 	manifest := ""
 	orgRepoName := registry.Org + "/" + repoName
 	mv2, err := registry.v2Base.ManifestV2(orgRepoName, tag)
-	registry.Print("manifest: %s\n", mv2)
 	if err == nil {
 		resp, err := registry.v2Base.DownloadLayer(orgRepoName, mv2.Config.Digest)
-		registry.Print("response: %s\n", resp)
 		if err == nil {
 			manifest, err = objects.GetSeedManifestFromBlob(resp)
 		}

--- a/registry/dockerhub/repositories.go
+++ b/registry/dockerhub/repositories.go
@@ -125,8 +125,10 @@ func (registry *DockerHubRegistry) ImagesWithManifests() ([]objects.Image, error
 func (registry *DockerHubRegistry) GetImageManifest(repoName, tag string) (string, error) {
 	manifest := ""
 	mv2, err := registry.v2Base.ManifestV2(repoName, tag)
+	registry.Print(mv2)
 	if err == nil {
 		resp, err := registry.v2Base.DownloadLayer(repoName, mv2.Config.Digest)
+		registry.Print(resp)
 		if err == nil {
 			manifest, err = objects.GetSeedManifestFromBlob(resp)
 		}

--- a/registry/registry_test.go
+++ b/registry/registry_test.go
@@ -233,6 +233,7 @@ func TestGetImageManifest(t *testing.T) {
 	}{
 		{0, "asdfasdf", "aaaa", "", "", "", "unexpected end of JSON input"},
 		{0, "extractor-0.1.0-seed", "0.1.0", "extractor", "0.1.0", "0.1.0", ""},
+		{0, "gpu-test-1.0.0-seed", "1.0.0", "gpu-test", "1.0.0", "1.0.0", ""},
 		{1, "my-job-0.1.0-seed", "0.1.0", "my-job", "0.1.0", "0.1.0", ""},
 	}
 

--- a/util/docker.go
+++ b/util/docker.go
@@ -288,6 +288,33 @@ func StartRegistry() error {
 	return nil
 }
 
+func ResetTestdata() error {
+	PrintUtil("Resetting testdata........................\n.\n.\n.\n.\n.\n")
+	var errs bytes.Buffer
+
+	PrintUtil("INFO: Resetting testdata...\n")
+	cmd := exec.Command("../resetTestdata.sh")
+	cmd.Stderr = io.MultiWriter(os.Stderr, &errs)
+	cmd.Stdout = os.Stdout
+
+	err := cmd.Run()
+
+	// check for errors on stderr first; it will likely have more explanation than cmd.Run
+	if errs.String() != "" {
+		PrintUtil("ERROR: Error resetting testdata. %s\n", errs.String())
+		PrintUtil("Exiting seed...\n")
+		return errors.New(errs.String())
+	}
+
+	if err != nil {
+		PrintUtil("ERROR: Error resetting testdata. %s\n",
+			err.Error())
+		return err
+	}
+
+	return nil
+}
+
 //Dockerpull pulls specified image from remote repository (default docker.io)
 //returns the name of the remote image retrieved, if any
 func DockerPull(image, registry, org, username, password string) (string, error) {


### PR DESCRIPTION
Removed docker pull code to get seed manifests for docker hub and replaced with v2 registry methods.  Getting the list of images still uses the web api instead of the v2 registry api because /v2/_catalog is disabled for docker hub.