### PR TITLE
2 fixes

### DIFF
--- a/registry/registry_test.go
+++ b/registry/registry_test.go
@@ -55,7 +55,7 @@ func TestRepositories(t *testing.T) {
 		expect   string
 		errStr   string
 	}{
-		{0, "[addition-job-0.0.1-seed extractor-0.1.0-seed gpu-test-1.0.0-seed my-job-0.1.0-seed my-job-0.1.2-seed my-job-1.0.0-seed]", ""},
+		{0, "[addition-job-0.0.1-seed extractor-0.1.0-seed flip-image-1.0.0-seed grayscale-image-1.0.0-seed my-job-0.1.0-seed my-job-0.1.2-seed my-job-1.0.0-seed]", ""},
 		{1, "[my-job-0.1.0-seed]", ""},
 	}
 
@@ -129,7 +129,7 @@ func TestImages(t *testing.T) {
 		expect   string
 		errStr   string
 	}{
-		{0, "[addition-job-0.0.1-seed:1.0.0 extractor-0.1.0-seed:0.1.0 gpu-test-1.0.0-seed:1.0.0 my-job-0.1.0-seed:0.1.0 my-job-0.1.2-seed:2.0.0 my-job-1.0.0-seed:0.1.0]", ""},
+		{0, "[addition-job-0.0.1-seed:1.0.0 extractor-0.1.0-seed:0.1.0 flip-image-1.0.0-seed:1.0.0 grayscale-image-1.0.0-seed:1.0.0 my-job-0.1.0-seed:0.1.0 my-job-0.1.2-seed:2.0.0 my-job-1.0.0-seed:0.1.0]", ""},
 		{1, "[my-job-0.1.0-seed:0.1.0]", ""},
 		{2, "[]", ""},
 	}
@@ -233,7 +233,6 @@ func TestGetImageManifest(t *testing.T) {
 	}{
 		{0, "asdfasdf", "aaaa", "", "", "", "unexpected end of JSON input"},
 		{0, "extractor-0.1.0-seed", "0.1.0", "extractor", "0.1.0", "0.1.0", ""},
-		{0, "gpu-test-1.0.0-seed", "1.0.0", "gpu-test", "1.0.0", "1.0.0", ""},
 		{1, "my-job-0.1.0-seed", "0.1.0", "my-job", "0.1.0", "0.1.0", ""},
 	}
 

--- a/util/docker.go
+++ b/util/docker.go
@@ -336,8 +336,9 @@ func DockerPull(image, registry, org, username, password string) (string, error)
 		registry = constants.DefaultRegistry
 	}
 
-	registry = strings.Replace(registry, "https://hub.docker.com/", "docker.io", 1)
-
+	registry = strings.Replace(registry, "https://hub.docker.com", "docker.io", 1)
+	registry = strings.TrimSuffix(registry, "/")
+	
 	remoteImage := fmt.Sprintf("%s/%s", registry, image)
 
 	if org != "" {

--- a/util/docker.go
+++ b/util/docker.go
@@ -336,7 +336,7 @@ func DockerPull(image, registry, org, username, password string) (string, error)
 		registry = constants.DefaultRegistry
 	}
 
-	registry = strings.Replace(registry, "https://hub.docker.com", "docker.io", 1)
+	registry = strings.Replace(registry, "https://hub.docker.com/", "docker.io", 1)
 
 	remoteImage := fmt.Sprintf("%s/%s", registry, image)
 

--- a/util/utils.go
+++ b/util/utils.go
@@ -9,6 +9,12 @@ import (
 
 type PrintCallback func(format string, args ...interface{})
 
+func init() {
+	if PrintUtil == nil {
+		InitPrinter(PrintErr)
+	}
+}
+
 /*
  * Print messages to stderr
  */

--- a/util/utils.go
+++ b/util/utils.go
@@ -9,12 +9,6 @@ import (
 
 type PrintCallback func(format string, args ...interface{})
 
-func init() {
-	if PrintUtil == nil {
-		InitPrinter(PrintErr)
-	}
-}
-
 /*
  * Print messages to stderr
  */


### PR DESCRIPTION
1. added the `/` to the `strings.Replace` call because I was getting double slashes between registry and image when calling `DockerPull` like this: 
```
image, err := util.DockerPull(seedImage, "", "", "", "")
```
Before: 
![Screenshot 2019-05-27 15 47 00](https://user-images.githubusercontent.com/22593495/58437276-40f92e80-8097-11e9-8fa9-b5161d47a7d9.png)

After:
![Screenshot 2019-05-27 15 47 22](https://user-images.githubusercontent.com/22593495/58437292-4d7d8700-8097-11e9-8c4d-9bba52c072ce.png)

### Please advise if this fix should be conducted elsewhere in `DockerPull`

2. added an `init()` function to `Utils` because I was getting an error that boiled down to `PrintUtil` not being initialized. 

![Screenshot 2019-05-27 15 48 09](https://user-images.githubusercontent.com/22593495/58437403-cda3ec80-8097-11e9-995d-52526aeb37e1.png)
