### PR TITLE
#27 - Quieter Testing

### DIFF
--- a/registry/containeryard/registry.go
+++ b/registry/containeryard/registry.go
@@ -3,6 +3,7 @@ package containeryard
 import (
 	"fmt"
 	"net/http"
+	"os"
 	"strings"
 
 	"github.com/heroku/docker-registry-client/registry"
@@ -28,7 +29,7 @@ func (r *ContainerYardRegistry) Name() string {
 //New creates a new docker hub registry from the given URL
 func New(registryUrl, org, username, password string) (*ContainerYardRegistry, error) {
 	if util.PrintUtil == nil {
-		util.InitPrinter(util.PrintErr)
+		util.InitPrinter(util.PrintErr, os.Stderr, os.Stdout)
 	}
 	url := strings.TrimSuffix(registryUrl, "/")
 	reg, err := registry.New(url, username, password)

--- a/registry/dockerhub/registry.go
+++ b/registry/dockerhub/registry.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"os"
 	"strings"
 
 	"github.com/heroku/docker-registry-client/registry"
@@ -23,7 +24,7 @@ type DockerHubRegistry struct {
 //New creates a new docker hub registry from the given URL
 func New(registryUrl, org, username, password string) (*DockerHubRegistry, error) {
 	if util.PrintUtil == nil {
-		util.InitPrinter(util.PrintErr)
+		util.InitPrinter(util.PrintErr, os.Stderr, os.Stdout)
 	}
 	url := strings.TrimSuffix(registryUrl, "/")
 

--- a/registry/registry_test.go
+++ b/registry/registry_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 func TestMain(m *testing.M) {
-	util.InitPrinter(util.PrintErr)
+	util.InitPrinter(util.PrintErr, util.StdErr, util.StdErr)
 
 	code := m.Run()
 

--- a/registry/v2/registry.go
+++ b/registry/v2/registry.go
@@ -2,6 +2,7 @@ package v2
 
 import (
 	"errors"
+	"os"
 	"strings"
 
 	"github.com/heroku/docker-registry-client/registry"
@@ -20,7 +21,7 @@ type v2registry struct {
 
 func New(url, org, username, password string) (*v2registry, error) {
 	if util.PrintUtil == nil {
-		util.InitPrinter(util.PrintErr)
+		util.InitPrinter(util.PrintErr, os.Stderr, os.Stdout)
 	}
 
 	reg, err := registry.New(url, username, password)

--- a/util/docker.go
+++ b/util/docker.go
@@ -129,7 +129,7 @@ func Login(registry, username, password string) error {
 	var errs, out bytes.Buffer
 	args := []string{"login", "-u", username, "-p", password, registry}
 	cmd := exec.Command("docker", args...)
-	cmd.Stderr = io.MultiWriter(os.Stderr, &errs)
+	cmd.Stderr = io.MultiWriter(StdErr, &errs)
 	cmd.Stdout = &out
 
 	err := cmd.Run()
@@ -188,8 +188,9 @@ func Push(img string) error {
 	PrintUtil("INFO: Running Docker command:\ndocker push %s\n", img)
 	errs.Reset()
 	pushCmd := exec.Command("docker", "push", img)
-	pushCmd.Stderr = io.MultiWriter(os.Stderr, &errs)
-	pushCmd.Stdout = os.Stdout
+	pushCmd.Stderr = io.MultiWriter(StdErr, &errs)
+	pushCmd.Stdout = StdOut
+
 
 	// Run docker push
 	if err := pushCmd.Run(); err != nil {

--- a/util/docker.go
+++ b/util/docker.go
@@ -129,7 +129,11 @@ func Login(registry, username, password string) error {
 	var errs, out bytes.Buffer
 	args := []string{"login", "-u", username, "-p", password, registry}
 	cmd := exec.Command("docker", args...)
-	cmd.Stderr = io.MultiWriter(StdErr, &errs)
+	if StdErr != nil {
+		cmd.Stderr = io.MultiWriter(StdErr, &errs)
+	} else {
+		cmd.Stderr = &errs
+	}
 	cmd.Stdout = &out
 
 	err := cmd.Run()
@@ -163,8 +167,12 @@ func Tag(origImg, img string) error {
 		PrintUtil("INFO: Tagging image %s as %s\n", origImg, img)
 		PrintUtil("INFO: Running Docker command:\ndocker tag %s %s\n", origImg, img)
 		tagCmd := exec.Command("docker", "tag", origImg, img)
-		tagCmd.Stderr = io.MultiWriter(os.Stderr, &errs)
-		tagCmd.Stdout = os.Stderr
+		if StdErr != nil {
+			tagCmd.Stderr = io.MultiWriter(StdErr, &errs)
+		} else {
+			tagCmd.Stderr = &errs
+		}
+		tagCmd.Stdout = StdErr
 
 		if err := tagCmd.Run(); err != nil {
 			PrintUtil("ERROR: Error executing docker tag. %s\n",
@@ -188,8 +196,12 @@ func Push(img string) error {
 	PrintUtil("INFO: Running Docker command:\ndocker push %s\n", img)
 	errs.Reset()
 	pushCmd := exec.Command("docker", "push", img)
-	pushCmd.Stderr = io.MultiWriter(StdErr, &errs)
-	pushCmd.Stdout = StdOut
+	if StdErr != nil {
+		pushCmd.Stderr = io.MultiWriter(StdErr, &errs)
+	} else {
+		pushCmd.Stderr = &errs
+	}
+	pushCmd.Stdout = StdErr
 
 
 	// Run docker push
@@ -216,8 +228,12 @@ func RemoveImage(img string) error {
 	PrintUtil("INFO: Removing local image %s\n", img)
 	PrintUtil("INFO: Running Docker command:\ndocker rmi %s\n", img)
 	rmiCmd := exec.Command("docker", "rmi", img)
-	rmiCmd.Stderr = io.MultiWriter(os.Stderr, &errs)
-	rmiCmd.Stdout = os.Stdout
+	if StdErr != nil {
+		rmiCmd.Stderr = io.MultiWriter(StdErr, &errs)
+	} else {
+		rmiCmd.Stderr = &errs
+	}
+	rmiCmd.Stdout = StdErr
 
 	if err := rmiCmd.Run(); err != nil {
 		PrintUtil("ERROR: Error executing docker rmi. %s\n",
@@ -242,8 +258,12 @@ func RestartRegistry() error {
 
 	PrintUtil("INFO: Restarting test registry...\n")
 	cmd := exec.Command("../restartRegistry.sh")
-	cmd.Stderr = io.MultiWriter(os.Stderr, &errs)
-	cmd.Stdout = os.Stdout
+	if StdErr != nil {
+		cmd.Stderr = io.MultiWriter(StdErr, &errs)
+	} else {
+		cmd.Stderr = &errs
+	}
+	cmd.Stdout = StdErr
 
 	err := cmd.Run()
 
@@ -269,8 +289,12 @@ func StartRegistry() error {
 
 	PrintUtil("INFO: Starting test registry...\n")
 	cmd := exec.Command("../startRegistry.sh")
-	cmd.Stderr = io.MultiWriter(os.Stderr, &errs)
-	cmd.Stdout = os.Stdout
+	if StdErr != nil {
+		cmd.Stderr = io.MultiWriter(StdErr, &errs)
+	} else {
+		cmd.Stderr = &errs
+	}
+	cmd.Stdout = StdErr
 
 	err := cmd.Run()
 
@@ -295,8 +319,12 @@ func ResetTestdata() error {
 
 	PrintUtil("INFO: Resetting testdata...\n")
 	cmd := exec.Command("../resetTestdata.sh")
-	cmd.Stderr = io.MultiWriter(os.Stderr, &errs)
-	cmd.Stdout = os.Stdout
+	if StdErr != nil {
+		cmd.Stderr = io.MultiWriter(StdErr, &errs)
+	} else {
+		cmd.Stderr = &errs
+	}
+	cmd.Stdout = StdErr
 
 	err := cmd.Run()
 
@@ -356,7 +384,11 @@ func DockerPull(image, registry, org, username, password string) (string, error)
 	}
 	PrintUtil("\n")
 	pullCmd := exec.Command("docker", pullArgs...)
-	pullCmd.Stderr = io.MultiWriter(os.Stderr, &errs)
+	if StdErr != nil {
+		pullCmd.Stderr = io.MultiWriter(StdErr, &errs)
+	} else {
+		pullCmd.Stderr = &errs
+	}
 	pullCmd.Stdout = &out
 
 	err := pullCmd.Run()

--- a/util/file_test.go
+++ b/util/file_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func init() {
-	InitPrinter(PrintErr)
+	InitPrinter(Quiet, nil, nil)
 }
 
 func TestGetFullPath(t *testing.T) {

--- a/util/seed_strings_test.go
+++ b/util/seed_strings_test.go
@@ -7,7 +7,7 @@ import (
 )
 
 func init() {
-	InitPrinter(PrintErr)
+	InitPrinter(Quiet, nil, nil)
 }
 
 func TestUnescapeManifestLabel(t *testing.T) {

--- a/util/utils.go
+++ b/util/utils.go
@@ -2,6 +2,7 @@ package util
 
 import (
 	"fmt"
+	"io"
 	"log"
 	"os"
 	"time"
@@ -31,9 +32,13 @@ func Quiet(format string, args ...interface{}) {
 }
 
 var PrintUtil PrintCallback
+var StdErr io.Writer
+var StdOut io.Writer
 
-func InitPrinter(callback PrintCallback) {
+func InitPrinter(callback PrintCallback, stderr, stdout io.Writer) {
 	PrintUtil = callback
+	StdErr = stderr
+	StdOut = stdout
 }
 
 //TimeTrack function for timing function calls. Usage:

--- a/util/variable_test.go
+++ b/util/variable_test.go
@@ -6,7 +6,7 @@ import (
 )
 
 func init() {
-	InitPrinter(PrintErr)
+	InitPrinter(Quiet, nil, nil)
 }
 
 func TestGetNormalizedVariable(t *testing.T) {


### PR DESCRIPTION
Allow for setting stdout and stderr to nil when testing so docker commands don't spew all over the console when tests fail.