### PR TITLE
#32 - Delete Images from Registries

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -26,7 +26,7 @@ stages:
 #  script:
 #    - yum install golang -y
 #    - yum install docker -y
-#    - docker run -d -p 5000:5000 --restart=always --name registry -v `pwd`/auth:/auth -e "REGISTRY_AUTH=htpasswd" -e "REGISTRY_AUTH_HTPASSWD_REALM=Registry Realm" -e REGISTRY_AUTH_HTPASSWD_PATH=/auth/htpasswd $REGISTRY_IMAGE
+#    - docker run -d -p 5000:5000 --restart=always --name registry -v `pwd`/auth:/auth -e "REGISTRY_AUTH=htpasswd" -e "REGISTRY_AUTH_HTPASSWD_REALM=Registry Realm" -e REGISTRY_AUTH_HTPASSWD_PATH=/auth/htpasswd -e REGISTRY_STORAGE_DELETE_ENABLED=true $REGISTRY_IMAGE
 #    - ./build-test-images.sh
 #    - go test ./...
 #  only:

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ services:
 
 script:
   - echo "Validating formatting with gofmt..." && gofmt -l .
-  - docker run -d -p 5000:5000 --restart=always --name registry -v `pwd`/auth:/auth -e "REGISTRY_AUTH=htpasswd" -e "REGISTRY_AUTH_HTPASSWD_REALM=Registry Realm" -e REGISTRY_AUTH_HTPASSWD_PATH=/auth/htpasswd registry:2
+  - docker run -d -p 5000:5000 --restart=always --name registry -v `pwd`/auth:/auth -e "REGISTRY_AUTH=htpasswd" -e "REGISTRY_AUTH_HTPASSWD_REALM=Registry Realm" -e REGISTRY_AUTH_HTPASSWD_PATH=/auth/htpasswd -e REGISTRY_STORAGE_DELETE_ENABLED=true registry:2
   - ./build-test-images.sh
   - go test ./...
 

--- a/objects/Seed.go
+++ b/objects/Seed.go
@@ -361,7 +361,7 @@ func GetSeedManifestFromBlob(blob io.ReadCloser) (string, error) {
 
 func GetImageNameFromManifest(manifest, directory string) (string, error) {
 	seedFileName := ""
-	if manifest != "." {
+	if manifest != "." && manifest != "" {
 		seedFileName = util.GetFullPath(manifest, directory)
 		if _, err := os.Stat(seedFileName); os.IsNotExist(err) {
 			util.PrintUtil("ERROR: Seed manifest not found. %s\n", err.Error())

--- a/objects/Seed.go
+++ b/objects/Seed.go
@@ -358,3 +358,31 @@ func GetSeedManifestFromBlob(blob io.ReadCloser) (string, error) {
 
 	return seedStr, err
 }
+
+func GetImageNameFromManifest(manifest string) (string, error) {
+	seedFileName := ""
+	if manifest != "." {
+		seedFileName = util.GetFullPath(manifest, "")
+		if _, err := os.Stat(seedFileName); os.IsNotExist(err) {
+			util.PrintUtil("ERROR: Seed manifest not found. %s\n", err.Error())
+			return "", err
+		}
+	} else {
+		temp, err := util.SeedFileName(".")
+		seedFileName = temp
+		if err != nil && !os.IsNotExist(err) {
+			util.PrintUtil("ERROR: %s\n", err.Error())
+			return "", err
+		}
+	}
+
+	util.PrintUtil("INFO: Attempting to get image name from manifest: %s", seedFileName)
+
+	// retrieve seed from seed manifest
+	seed := SeedFromManifestFile(seedFileName)
+
+	// Retrieve docker image name
+	image := BuildImageName(&seed)
+
+	return image, nil
+}

--- a/objects/Seed.go
+++ b/objects/Seed.go
@@ -371,12 +371,12 @@ func GetImageNameFromManifest(manifest, directory string) (string, error) {
 		temp, err := util.SeedFileName(directory)
 		seedFileName = temp
 		if err != nil {
-			util.PrintUtil("ERROR: %s\n", err.Error())
+			util.PrintUtil("ERROR: Seed manifest not found. Error=%s\n", err.Error())
 			return "", err
 		}
 	}
 
-	util.PrintUtil("INFO: Attempting to get image name from manifest: %s", seedFileName)
+	util.PrintUtil("INFO: Found manifest: %s\n", seedFileName)
 
 	// retrieve seed from seed manifest
 	seed := SeedFromManifestFile(seedFileName)

--- a/objects/Seed.go
+++ b/objects/Seed.go
@@ -359,16 +359,16 @@ func GetSeedManifestFromBlob(blob io.ReadCloser) (string, error) {
 	return seedStr, err
 }
 
-func GetImageNameFromManifest(manifest string) (string, error) {
+func GetImageNameFromManifest(manifest, directory string) (string, error) {
 	seedFileName := ""
 	if manifest != "." {
-		seedFileName = util.GetFullPath(manifest, "")
+		seedFileName = util.GetFullPath(manifest, directory)
 		if _, err := os.Stat(seedFileName); os.IsNotExist(err) {
 			util.PrintUtil("ERROR: Seed manifest not found. %s\n", err.Error())
 			return "", err
 		}
 	} else {
-		temp, err := util.SeedFileName(".")
+		temp, err := util.SeedFileName(directory)
 		seedFileName = temp
 		if err != nil && !os.IsNotExist(err) {
 			util.PrintUtil("ERROR: %s\n", err.Error())

--- a/objects/Seed.go
+++ b/objects/Seed.go
@@ -370,7 +370,7 @@ func GetImageNameFromManifest(manifest, directory string) (string, error) {
 	} else {
 		temp, err := util.SeedFileName(directory)
 		seedFileName = temp
-		if err != nil && !os.IsNotExist(err) {
+		if err != nil {
 			util.PrintUtil("ERROR: %s\n", err.Error())
 			return "", err
 		}

--- a/registry/RegistryFactory.go
+++ b/registry/RegistryFactory.go
@@ -19,6 +19,7 @@ type RepositoryRegistry interface {
 	Images() ([]string, error)
 	ImagesWithManifests() ([]objects.Image, error)
 	GetImageManifest(repoName, tag string) (string, error)
+	RemoveImage(reponame, tag string) error
 }
 
 type RepoRegistryFactory func(url, org, username, password string) (RepositoryRegistry, error)

--- a/registry/containeryard/repositories.go
+++ b/registry/containeryard/repositories.go
@@ -192,3 +192,12 @@ func (registry *ContainerYardRegistry) GetImageManifest(repoName, tag string) (s
 
 	return manifest, err
 }
+
+func (registry *ContainerYardRegistry) RemoveImage(repoName, tag string) error {
+	mv2, err := registry.v2Base.ManifestV2(repoName, tag)
+	if err == nil {
+		err = registry.v2Base.DeleteManifest(repoName, mv2.Config.Digest)
+	}
+
+	return err
+}

--- a/registry/containeryard/repositories.go
+++ b/registry/containeryard/repositories.go
@@ -194,9 +194,9 @@ func (registry *ContainerYardRegistry) GetImageManifest(repoName, tag string) (s
 }
 
 func (registry *ContainerYardRegistry) RemoveImage(repoName, tag string) error {
-	mv2, err := registry.v2Base.ManifestV2(repoName, tag)
+	digest, err := registry.v2Base.ManifestDigestV2(repoName, tag)
 	if err == nil {
-		err = registry.v2Base.DeleteManifest(repoName, mv2.Config.Digest)
+		err = registry.v2Base.DeleteManifest(repoName, digest)
 	}
 
 	return err

--- a/registry/dockerhub/repositories.go
+++ b/registry/dockerhub/repositories.go
@@ -142,9 +142,9 @@ func (registry *DockerHubRegistry) GetImageManifest(repoName, tag string) (strin
 
 func (registry *DockerHubRegistry) RemoveImage(repoName, tag string) error {
 	orgRepoName := registry.Org + "/" + repoName
-	mv2, err := registry.v2Base.ManifestV2(orgRepoName, tag)
+	digest, err := registry.v2Base.ManifestDigestV2(orgRepoName, tag)
 	if err == nil {
-		err = registry.v2Base.DeleteManifest(orgRepoName, mv2.Config.Digest)
+		err = registry.v2Base.DeleteManifest(orgRepoName, digest)
 	}
 
 	return err

--- a/registry/dockerhub/repositories.go
+++ b/registry/dockerhub/repositories.go
@@ -139,3 +139,13 @@ func (registry *DockerHubRegistry) GetImageManifest(repoName, tag string) (strin
 
 	return manifest, err
 }
+
+func (registry *DockerHubRegistry) RemoveImage(repoName, tag string) error {
+	orgRepoName := registry.Org + "/" + repoName
+	mv2, err := registry.v2Base.ManifestV2(orgRepoName, tag)
+	if err == nil {
+		err = registry.v2Base.DeleteManifest(orgRepoName, mv2.Config.Digest)
+	}
+
+	return err
+}

--- a/registry/registry_test.go
+++ b/registry/registry_test.go
@@ -268,6 +268,48 @@ func TestGetImageManifest(t *testing.T) {
 	}
 }
 
+func TestRemoveImage(t *testing.T) {
+	cases := []struct {
+		regIndex        int
+		repoName        string
+		tag             string
+		expectedResult  bool
+		errStr          string
+	}{
+		{0, "asdfasdf", "aaaa", false, "UNAUTHORIZED"},
+		{1, "my-job-0.1.0-seed", "0.1.0", true, ""},
+	}
+
+	regs, err := CreateTestRegistries()
+
+	if regs == nil || err != nil {
+		t.Errorf("Error creating test registries: %v\n", err)
+	}
+
+	for _, c := range cases {
+		reg := regs[c.regIndex]
+
+		err := reg.RemoveImage(c.repoName, c.tag)
+
+		_, err2 := reg.GetImageManifest(c.repoName, c.tag)
+
+		if err == nil && c.expectedResult == false {
+			t.Errorf("RemoveImage succeeded when it was expected to fail\n")
+		}
+		if err != nil && c.expectedResult == true {
+			t.Errorf("RemoveImage failed when it was expected to succeed\n")
+		}
+		if err != nil && !strings.Contains(err.Error(), c.errStr) {
+			t.Errorf("RemoveImage returned an error: %v\n expected %v", err, c.errStr)
+		}
+
+		if c.expectedResult && err == nil && err2 == nil {
+			t.Errorf("RemoveImage did not remove image %v from registry!", c.repoName)
+		}
+	}
+}
+
+
 func CreateTestRegistries() ([]RepositoryRegistry, error) {
 	cases := []struct {
 		url      string

--- a/registry/registry_test.go
+++ b/registry/registry_test.go
@@ -297,7 +297,7 @@ func TestRemoveImage(t *testing.T) {
 			t.Errorf("RemoveImage succeeded when it was expected to fail\n")
 		}
 		if err != nil && c.expectedResult == true {
-			t.Errorf("RemoveImage failed when it was expected to succeed\n")
+			t.Errorf("RemoveImage failed when it was expected to succeed. Error: %v\n", err)
 		}
 		if err != nil && !strings.Contains(err.Error(), c.errStr) {
 			t.Errorf("RemoveImage returned an error: %v\n expected %v", err, c.errStr)

--- a/registry/registry_test.go
+++ b/registry/registry_test.go
@@ -276,7 +276,7 @@ func TestRemoveImage(t *testing.T) {
 		expectedResult  bool
 		errStr          string
 	}{
-		{0, "asdfasdf", "aaaa", false, "UNAUTHORIZED"},
+		{0, "asdfasdf", "aaaa", false, "401"},
 		{1, "my-job-0.1.0-seed", "0.1.0", true, ""},
 	}
 

--- a/registry/v2/registry.go
+++ b/registry/v2/registry.go
@@ -121,3 +121,12 @@ func (v2 *v2registry) GetImageManifest(repoName, tag string) (string, error) {
 
 	return manifest, err
 }
+
+func (v2 *v2registry) RemoveImage(repoName, tag string) error {
+	mv2, err := v2.r.ManifestV2(repoName, tag)
+	if err == nil {
+		err = v2.r.DeleteManifest(repoName, mv2.Config.Digest)
+	}
+
+	return err
+}

--- a/registry/v2/registry.go
+++ b/registry/v2/registry.go
@@ -123,9 +123,10 @@ func (v2 *v2registry) GetImageManifest(repoName, tag string) (string, error) {
 }
 
 func (v2 *v2registry) RemoveImage(repoName, tag string) error {
-	mv2, err := v2.r.ManifestV2(repoName, tag)
+	digest, err := v2.r.ManifestDigestV2(repoName, tag)
+
 	if err == nil {
-		err = v2.r.DeleteManifest(repoName, mv2.Config.Digest)
+		err = v2.r.DeleteManifest(repoName, digest)
 	}
 
 	return err

--- a/restartRegistry.sh
+++ b/restartRegistry.sh
@@ -2,7 +2,7 @@
 cd "$(dirname "$0")"
 pwd
 docker rm $(docker ps -a -q  --filter ancestor=registry:2) -f
-docker run -d -p 5000:5000 --name registry -v `pwd`/auth:/auth -e "REGISTRY_AUTH=htpasswd" -e "REGISTRY_AUTH_HTPASSWD_REALM=Registry Realm" -e REGISTRY_AUTH_HTPASSWD_PATH=/auth/htpasswd registry:2
+docker run -d -p 5000:5000 --name registry -v `pwd`/auth:/auth -e "REGISTRY_AUTH=htpasswd" -e "REGISTRY_AUTH_HTPASSWD_REALM=Registry Realm" -e REGISTRY_AUTH_HTPASSWD_PATH=/auth/htpasswd -e REGISTRY_STORAGE_DELETE_ENABLED=true registry:2
 
 i=0
 until [ ${i} -ge 10 ] || $(curl --output /dev/null --silent --head --fail http://localhost:5000); do

--- a/startRegistry.sh
+++ b/startRegistry.sh
@@ -8,7 +8,7 @@ if [ ! "$(docker ps -q --filter ancestor=registry:2)" ]; then
         docker rm $(docker ps -a -q  --filter ancestor=registry:2) -f
     fi
     # run your container
-    docker run -d -p 5000:5000 --name registry -v `pwd`/auth:/auth -e "REGISTRY_AUTH=htpasswd" -e "REGISTRY_AUTH_HTPASSWD_REALM=Registry Realm" -e REGISTRY_AUTH_HTPASSWD_PATH=/auth/htpasswd registry:2
+    docker run -d -p 5000:5000 --name registry -v `pwd`/auth:/auth -e "REGISTRY_AUTH=htpasswd" -e "REGISTRY_AUTH_HTPASSWD_REALM=Registry Realm" -e REGISTRY_AUTH_HTPASSWD_PATH=/auth/htpasswd -e REGISTRY_STORAGE_DELETE_ENABLED=true registry:2
 fi
 
 i=0

--- a/vendor/github.com/heroku/docker-registry-client/registry/layer.go
+++ b/vendor/github.com/heroku/docker-registry-client/registry/layer.go
@@ -21,6 +21,24 @@ func (registry *Registry) DownloadLayer(repository string, digest digest.Digest)
 	return resp.Body, nil
 }
 
+func (registry *Registry) DeleteLayer(repository string, digest digest.Digest) error {
+	url := registry.url("/v2/%s/blobs/%s", repository, digest)
+	registry.Logf("registry.layer.delete url=%s repository=%s digest=%s", url, repository, digest)
+
+	req, err := http.NewRequest("DELETE", url, nil)
+	if err != nil {
+		return err
+	}
+	resp, err := registry.Client.Do(req)
+	if resp != nil {
+		defer resp.Body.Close()
+	}
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
 func (registry *Registry) UploadLayer(repository string, digest digest.Digest, content io.Reader) error {
 	uploadUrl, err := registry.initiateUpload(repository)
 	if err != nil {

--- a/vendor/github.com/heroku/docker-registry-client/registry/manifest.go
+++ b/vendor/github.com/heroku/docker-registry-client/registry/manifest.go
@@ -83,6 +83,26 @@ func (registry *Registry) ManifestDigest(repository, reference string) (digest.D
 	return digest.ParseDigest(resp.Header.Get("Docker-Content-Digest"))
 }
 
+func (registry *Registry) ManifestDigestV2(repository, reference string) (digest.Digest, error) {
+	url := registry.url("/v2/%s/manifests/%s", repository, reference)
+	registry.Logf("registry.manifest.head url=%s repository=%s reference=%s", url, repository, reference)
+
+	req, err := http.NewRequest("HEAD", url, nil)
+	if err != nil {
+		return "", err
+	}
+
+	req.Header.Set("Accept", manifestV2.MediaTypeManifest)
+	resp, err := registry.Client.Do(req)
+	if resp != nil {
+		defer resp.Body.Close()
+	}
+	if err != nil {
+		return "", err
+	}
+	return digest.ParseDigest(resp.Header.Get("Docker-Content-Digest"))
+}
+
 func (registry *Registry) DeleteManifest(repository string, digest digest.Digest) error {
 	url := registry.url("/v2/%s/manifests/%s", repository, digest)
 	registry.Logf("registry.manifest.delete url=%s repository=%s reference=%s", url, repository, digest)


### PR DESCRIPTION
This update allows for deleting manifests from a docker registry.  Subsequent calls to this library to list images should no longer show the deleted image but disk space will not yet be reclaimed.  Garbage collection must be performed periodically to clean up disk space.